### PR TITLE
Update Indenting.plist

### DIFF
--- a/Preferences/Indenting.plist
+++ b/Preferences/Indenting.plist
@@ -16,6 +16,12 @@
 		<string>^\s*.*(:|-) ?(&amp;\w+)?(\{[^}"']*|\([^)"']*)?$</string>
 		<key>indentOnPaste</key>
 		<string>simple</string>
+		<key>foldingIndentedBlockIgnore</key>
+		<string>^\s*#</string>
+		<key>foldingIndentedBlockStart</key>
+		<string>^\s*.*(:|-) ?(&amp;\w+)?(\{[^}"']*|\([^)"']*)?$</string>
+		<key>foldingStartMarker</key>
+		<string>^\s*"""(?=.)(?!.*""")</string>
 	</dict>
 	<key>uuid</key>
 	<string>78CB70FF-5071-11DA-B402-000A95AF0064</string>


### PR DESCRIPTION
Fix non-working folding/unfolding.

foldingStartMarker was copied from Python setting.
foldingIndentedBlockIgnore was copied from the 'Fold on the Dotted Line'
section in http://blog.macromates.com/2012/the-layout-engine/
