### PR TITLE
Port some improved handling of multiline string blocks

### DIFF
--- a/Syntaxes/YAML.plist
+++ b/Syntaxes/YAML.plist
@@ -19,7 +19,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^(\s*)(?:(-)|(?:(-\s*)?(\w+\s*(:))))\s*(\||&gt;)</string>
+			<string>^(\s*)(?:(-)|(?:(-\s*)?(\S+\s*(:))))\s*(\||&gt;)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>2</key>
@@ -44,7 +44,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>^(?!^\1)|^(?=\1(-|\w+\s*:)|#)</string>
+			<string>^((?=\s*#(?!#))|(?!\1\s+)(?=\s*(-|\S+\s*:)|#))</string>
 			<key>name</key>
 			<string>string.unquoted.block.yaml</string>
 			<key>patterns</key>


### PR DESCRIPTION
* Allows keys with decimals to be matched
* Allows proper syntax handling of `#` within a multiline block
* Allows for ending with an indented comment

For more information see https://github.com/atom/language-yaml/pull/19 (it has pictures!) and https://github.com/atom/language-yaml/commit/6e31ad19f18bc488184c7299ba8e9e9af95cb461.