### PR TITLE
Allow `&` sign in unquoted strings

### DIFF
--- a/Syntaxes/YAML.plist
+++ b/Syntaxes/YAML.plist
@@ -144,7 +144,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(?:(?:(-\s*)?(\w+\s*(:)))|(-))\s*(?:((")[^"]*("))|((')[^']*('))|([^,{}&amp;#\[\]]+))\s*</string>
+			<string>(?:(?:(-\s*)?(\w+\s*(:)))|(-))\s*(?:((")[^"]*("))|((')[^']*('))|([^,{}#\[\]]+))\s*</string>
 			<key>name</key>
 			<string>string.unquoted.yaml</string>
 		</dict>


### PR DESCRIPTION
Hi,

this commit removes the ampersand from the characters that are not a part of an unquoted string/list element. As far as I know, there are two meanings for an ampersand that is part of an unquotes string — which itself is used as list element:  

If `&` is the first character, then the ampersand creates a reference. E.g.:

```python
from yaml import load

print(load(
    """
    - &ref bla
    - blubb
    - *ref
    """))
```

prints: `['bla', 'blubb', 'bla']`

Otherwise the ampersand is a valid character without any special meaning. E.g.:

```python
from yaml import load

print(load("""
    - H&i
    - Hi&
    """))
```

prints: `['H&i', 'Hi&']`

Kind regards,
  René