### PR TITLE
Add yaml keys to symbols list

### DIFF
--- a/Preferences/Symbol List.tmPreferences
+++ b/Preferences/Symbol List.tmPreferences
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Symbol List</string>
+	<key>scope</key>
+	<string>source.yaml entity.name.tag.yaml</string>
+	<key>settings</key>
+	<dict>
+		<key>showInSymbolList</key>
+		<string>1</string>
+	</dict>
+	<key>uuid</key>
+	<string>0A0DA1FC-59DE-4FD9-9A2C-63C6811A3C39</string>
+</dict>
+</plist>


### PR DESCRIPTION
Self explanatory request: I think it's useful to be able to use `CMD + SHIFT + T` to quickly navigate my enormous yml files. 

![image](https://cloud.githubusercontent.com/assets/840704/10239758/3534b4ce-6887-11e5-83f2-176e2bbf0490.png)
